### PR TITLE
[Hotfix] Update network module and add ref to anp

### DIFF
--- a/prod-networks/anp-prod.tf
+++ b/prod-networks/anp-prod.tf
@@ -11,11 +11,12 @@ resource "aci_application_profile" "payment_services" {
 
 module "network-prod-fe-01" {
   source  = "app.terraform.io/cisco-dcn-ecosystem/network/aci"
-  version = "0.0.1"
+  version = "0.0.2"
 
   name      = "prod_net_front_01"
   tenant_dn = local.tenant_dn
   vrf_dn    = local.vrf_dn
+  anp_dn    = aci_application_profile.payment_services.id
 
   type   = "L3"
   subnet = "192.168.1.1/24"


### PR DESCRIPTION
## Description
There has been an issue due to ANP not being a variable in module "Network". After fixing the module, apply hotfix to re-deploy EPG in the right ANP.

Change Request: **CR0004**